### PR TITLE
Actuate all joints with changes in one command

### DIFF
--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -490,7 +490,6 @@ void Robot::writeJoints()
     {
       //ROS_INFO_STREAM(" joint " << i << " : diff=" << diff);
       changed = true;
-      break;
     }
   }
 


### PR DESCRIPTION
Fixing https://github.com/ros-naoqi/pepper_dcm_robot/issues/5

Instead of writing joint by joint, this applies the position change to all the set of joints (as expected).